### PR TITLE
Switch to python3.11

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,14 +11,12 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - name: Set up Python 3.7
+    - name: Set up Python 3.11
       uses: actions/setup-python@v1
       with:
-        python-version: 3.7
+        python-version: 3.11
     - name: Install docker-compose and libs
       run: |
-        sudo curl -L "https://github.com/docker/compose/releases/download/1.23.2/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
-        sudo chmod +x /usr/local/bin/docker-compose
         sudo apt-get update
         sudo apt-get install -y libmysqlclient-dev build-essential
     - name: Install python dependencies

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,7 @@ jobs:
     - name: Install docker-compose and libs
       run: |
         sudo apt-get update
-        sudo apt-get install -y libmysqlclient-dev build-essential
+        sudo apt-get install -y libmysqlclient-dev build-essential docker-compose
     - name: Install python dependencies
       run: |
         python -m pip install --upgrade pip

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.7
+FROM python:3.11
 
 RUN mkdir app
 WORKDIR /app

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,4 @@
 pytest==6.1.2
 pytest-cov==2.10.1
-docker-compose==1.29.3
+docker-compose==1.29.2
 flake8==3.7.9

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,3 @@
-pytest==6.1.2
-pytest-cov==2.10.1
-docker-compose==1.29.2
-flake8==3.7.9
+flake8==6.1.0
+pytest==7.4.3
+pytest-cov==4.1.0

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,4 @@
 pytest==6.1.2
 pytest-cov==2.10.1
-docker-compose==1.27.4
+docker-compose==1.29.3
 flake8==3.7.9

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-Flask==2.0.2
-Jinja2==3.0.3
-uwsgi==2.0.19.1
-requests==2.25.1
-itsdangerous==2.0.1
+Flask==3.0.0
+Jinja2==3.1.2
+uwsgi==2.0.23
+requests==2.31.0
+itsdangerous==2.1.2


### PR DESCRIPTION
Changes:
- Update base image to python3.11-bookworm.
- Bump dependencies

Testing:
No performance changes were made.
Tested on local networks by running watchdog on nodes