### PR TITLE
Update watchdog client to pyproject, migrate to Hatchling

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,52 +18,55 @@ jobs:
       PIP_USERNAME: ${{ secrets.PIP_USERNAME }}
       PIP_PASSWORD: ${{ secrets.PIP_PASSWORD }}
     steps:
-    - uses: actions/checkout@v2
-    - name: Set up Python 3.13
-      uses: actions/setup-python@v1
-      with:
-        python-version: 3.13
-    - name: Install python dependencies - watchdog_client
-      working-directory: ./watchdog_client
-      run: |
-        python -m pip install --upgrade pip
-        pip install -e .
-        pip install -e .[dev]
-        pip install wheel
-    - name: Build library
-      working-directory: ./watchdog_client
-      run: |
-        export BRANCH=${GITHUB_REF##*/}
-        echo "Branch $BRANCH"
-        export VERSION=$(bash ./scripts/calculate_version.sh)
-        echo "VERSION=$VERSION" >> $GITHUB_ENV
-        echo "Version $VERSION"
-        bash ./scripts/build.sh
-    - name: Publish to pip
-      working-directory: ./watchdog_client
-      run: |
-        bash ./scripts/publish.sh
-    - name: Checkout code
-      uses: actions/checkout@master
-    - name: Build and publish container
-      run: |
-        export BRANCH=${GITHUB_REF##*/}
-        echo "Branch $BRANCH"
-        export VERSION=$(bash ./scripts/calculate_version.sh)
-        echo "VERSION=$VERSION" >> $GITHUB_ENV
-        echo "Version $VERSION"
-        export RELEASE=true
-        echo "RELEASE=$RELEASE" >> $GITHUB_ENV
-        bash ./scripts/build_and_publish.sh
-    - name: Checkout code
-      uses: actions/checkout@master
-    - name: Create Release
-      id: create_release
-      uses: actions/create-release@v1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        tag_name: ${{ env.VERSION }}
-        release_name: ${{ env.VERSION }}
-        draft: false
-        prerelease: true
+      - uses: actions/checkout@v2
+      - name: Set up Python 3.13
+        uses: actions/setup-python@v1
+        with:
+          python-version: 3.13
+      - name: Install uv
+        run: |
+          curl -LsSf https://astral.sh/uv/install.sh | sh
+          echo "$HOME/.cargo/bin" >> $GITHUB_PATH
+      - name: Install python dependencies - watchdog_client
+        working-directory: ./watchdog_client
+        run: |
+          uv pip install build hatchling
+          uv pip install -e .
+          uv pip install -e .[dev]
+      - name: Build library
+        working-directory: ./watchdog_client
+        run: |
+          export BRANCH=${GITHUB_REF##*/}
+          echo "Branch $BRANCH"
+          export VERSION=$(bash ./scripts/calculate_version.sh)
+          echo "VERSION=$VERSION" >> $GITHUB_ENV
+          echo "Version $VERSION"
+          bash ./scripts/build.sh
+      - name: Publish to pip
+        working-directory: ./watchdog_client
+        run: |
+          bash ./scripts/publish.sh
+      - name: Checkout code
+        uses: actions/checkout@master
+      - name: Build and publish container
+        run: |
+          export BRANCH=${GITHUB_REF##*/}
+          echo "Branch $BRANCH"
+          export VERSION=$(bash ./scripts/calculate_version.sh)
+          echo "VERSION=$VERSION" >> $GITHUB_ENV
+          echo "Version $VERSION"
+          export RELEASE=true
+          echo "RELEASE=$RELEASE" >> $GITHUB_ENV
+          bash ./scripts/build_and_publish.sh
+      - name: Checkout code
+        uses: actions/checkout@master
+      - name: Create Release
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ env.VERSION }}
+          release_name: ${{ env.VERSION }}
+          draft: false
+          prerelease: true

--- a/watchdog_client/pyproject.toml
+++ b/watchdog_client/pyproject.toml
@@ -1,0 +1,29 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "skale-watchdog-client"
+version = "0.0.0"
+description = "SKALE Watchdog Client - SKALE and FAIR Nodes Health Checks"
+authors = [{ name = "SKALE Labs", email = "support@skalelabs.com" }]
+readme = "README.md"
+license = { file = "LICENSE" }
+requires-python = ">=3.13,<4"
+dependencies = ["requests>=2.31.0"]
+keywords = ["skale"]
+classifiers = [
+    "Development Status :: 5 - Production/Stable",
+    "Intended Audience :: Developers",
+    "Natural Language :: English",
+    "Programming Language :: Python :: 3.13",
+]
+
+[project.optional-dependencies]
+dev = ["twine>=5.0.0,<7", "build>=1.2.1"]
+
+[project.urls]
+Homepage = "https://github.com/skalenetwork/skale-watchdog"
+
+[tool.hatch.build.targets.wheel]
+packages = ["watchdog_client"]

--- a/watchdog_client/scripts/build.sh
+++ b/watchdog_client/scripts/build.sh
@@ -2,15 +2,23 @@
 
 set -e
 
-CURRENT_VERSION="$(python setup.py --version)"
+CURRENT_VERSION=$(grep '^version = ' pyproject.toml | sed 's/version = "\(.*\)"/\1/')
 
-sed -i "s/version='${CURRENT_VERSION}/version='${VERSION}/g" setup.py
+if [ -z "$VERSION" ]; then
+    echo "VERSION environment variable is not set"
+    exit 1
+fi
+
+if [[ "$OSTYPE" == "darwin"* ]]; then
+    sed -i '' "s/version = \"${CURRENT_VERSION}\"/version = \"${VERSION}\"/g" pyproject.toml
+else
+    sed -i "s/version = \"${CURRENT_VERSION}\"/version = \"${VERSION}\"/g" pyproject.toml
+fi
 
 rm -rf ./dist/*
 
-python setup.py sdist
-python setup.py bdist_wheel
+python -m build
 
 echo "==================================================================="
-echo "Done build: skale.py $VERSION/"
+echo "Done build: skale-watchdog-client $VERSION/"
 

--- a/watchdog_client/scripts/calculate_version.sh
+++ b/watchdog_client/scripts/calculate_version.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
-VERSION=$(cat $DIR/../../VERSION)
+VERSION=$(grep '^version = ' $DIR/../../pyproject.toml | cut -d'"' -f2)
 
 USAGE_MSG='Usage: BRANCH=[BRANCH] calculate_version.sh'
 

--- a/watchdog_client/scripts/install_python_dependencies.sh
+++ b/watchdog_client/scripts/install_python_dependencies.sh
@@ -2,7 +2,7 @@
 
 set -ea
 
-python -m pip install --upgrade pip
-pip install -e .
-pip install -e .[dev]
-pip install codecov pytest-cov
+uv pip install build hatchling
+uv pip install -e .
+uv pip install -e .[dev]
+uv pip install codecov pytest-cov


### PR DESCRIPTION
This pull request updates the Python packaging and build process for the `watchdog_client` to use modern standards and tools, replacing legacy `setup.py`-based workflows with a `pyproject.toml` configuration and the `uv` installer. The changes improve maintainability, compatibility, and build reliability.

**Packaging and Build System Modernization:**

* Added a new `pyproject.toml` file to define the project metadata, dependencies, and build system using `hatchling`, replacing the old `setup.py` approach.
* Updated the build script (`build.sh`) to extract and set the version from `pyproject.toml`, handle OS differences, and use `python -m build` for building distributions.
* Updated the version calculation script (`calculate_version.sh`) to read the version from `pyproject.toml` instead of a separate `VERSION` file.

**Dependency Installation Workflow:**

* Updated the GitHub Actions workflow (`publish.yml`) and local install scripts to use the `uv` installer for Python dependencies, replacing `pip` and streamlining the installation process. [[1]](diffhunk://#diff-551d1fcf87f78cc3bc18a7b332a4dc5d8773a512062df881c5aba28a6f5c48d7R26-R35) [[2]](diffhunk://#diff-18a7994be119353a3a3353f05665ca642c0c7274e4d8e0faff9c304187beac07L5-R8)

These changes collectively modernize the packaging and build pipeline, aligning it with current best practices for Python projects.