### PR TITLE
Fix publish pipeline

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -30,9 +30,9 @@ jobs:
       - name: Install python dependencies - watchdog_client
         working-directory: ./watchdog_client
         run: |
-          uv pip install build hatchling
-          uv pip install -e .
-          uv pip install -e .[dev]
+          uv pip install --system build hatchling
+          uv pip install --system -e .
+          uv pip install --system -e .[dev]
       - name: Build library
         working-directory: ./watchdog_client
         run: |


### PR DESCRIPTION
This pull request updates the installation steps for Python dependencies in the `publish.yml` GitHub Actions workflow. The main change is the addition of the `--system` flag to all `uv pip install` commands, which ensures that packages are installed into the system environment rather than a virtual environment.

Dependency installation process:

* Added the `--system` flag to all `uv pip install` commands for `build`, `hatchling`, and the local `watchdog_client` package, ensuring system-level installation.