### PR TITLE
Merge SKALE active and passive node pipelines

### DIFF
--- a/configs/__init__.py
+++ b/configs/__init__.py
@@ -29,8 +29,6 @@ HEALTHCHECK_ROUTES = {
         'ssl': get_api_url('ssl', 'status'),
     },
     'skale': {
-        'schains': get_api_url('health', 'schains'),
-        'ima': get_api_url('health', 'ima'),
         'schain-containers-versions': get_api_url('schains', 'container-versions'),
         'public-ip': get_api_url('node', 'public-ip'),
     },
@@ -42,6 +40,11 @@ HEALTHCHECK_ROUTES = {
 
 if not PASSIVE_NODE:
     HEALTHCHECK_ROUTES['common']['sgx'] = get_api_url('info', 'sgx')
+    HEALTHCHECK_ROUTES['skale']['schains'] = get_api_url('health', 'schains')
+    HEALTHCHECK_ROUTES['skale']['ima'] = get_api_url('health', 'ima')
+    HEALTHCHECK_ROUTES['skale']['validator-nodes'] = get_api_url('node', 'validator-nodes')
+
+
 
 API_TIMEOUT = 1000  # in seconds
 DEFAULT_TASK_INTERVAL = 60

--- a/configs/__init__.py
+++ b/configs/__init__.py
@@ -33,9 +33,6 @@ HEALTHCHECK_ROUTES = {
         'ima': get_api_url('health', 'ima'),
         'schain-containers-versions': get_api_url('schains', 'container-versions'),
         'public-ip': get_api_url('node', 'public-ip'),
-        'validator-nodes': get_api_url('node', 'validator-nodes'),
-        'sm-abi': get_api_url('node', 'sm-abi'),
-        'ima-abi': get_api_url('node', 'ima-abi'),
     },
     'fair': {
         'chain-checks': get_api_url('fair-chain', 'checks'),

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,3 +38,6 @@ log_cli_level = "INFO"
 log_cli_format = "[%(asctime)s] [%(levelname)8s] [%(threadName)s] %(message)s (%(filename)s:%(lineno)s)"
 log_cli_date_format = "%Y-%m-%d %H:%M:%S"
 filterwarnings = ["ignore::DeprecationWarning"]
+
+[tool.setuptools.packages.find]
+include = ["configs", "utils"]

--- a/watchdog_client/README.md
+++ b/watchdog_client/README.md
@@ -15,13 +15,16 @@ Supports Python 3.13+.
 ## Quick Start
 
 ```python
-from watchdog_client import SkaleNode, FairNode, FairPassiveNode
+from watchdog_client import SkaleNode, SkalePassiveNode, FairNode, FairPassiveNode
 
 # Base URL can be domain name or IP address of the node.
 skale_node = SkaleNode('my-skale-node.example.com')
-fair_node = FairNode('23.56.24.61')
+# Use SkalePassiveNode for SKALE nodes running in passive mode
+skale_passive = SkalePassiveNode('my-passive-skale-node.example.com')
+
+fair_node = FairNode('my-fair-node.example.com')
 # Use FairPassiveNode for FAIR nodes running in passive mode (no SGX endpoint)
-fair_passive = FairPassiveNode('23.56.24.62')
+fair_passive = FairPassiveNode('my-passive-fair-node.example.com')
 
 # Call any endpoint – each returns ApiResult (fields: data, error, status_code)
 r = skale_node.public_ip()
@@ -56,8 +59,15 @@ for name, res in results.items():
 * schain\_containers\_versions (maps to /schain-containers-versions)
 * public\_ip (maps to /public-ip)
 * validator\_nodes (maps to /validator-nodes)
-* sm\_abi\_hash (maps to /sm-abi)
-* ima\_abi\_hash (maps to /ima-abi)
+
+### SKALE Passive (`SkalePassiveNode`)
+
+Same as `SkaleNode`, except the following checks return an error (404), because they are not available on SKALE passive nodes:
+
+* sgx
+* schains
+* ima
+* validator\_nodes
 
 ### FAIR-specific (`FairNode`)
 

--- a/watchdog_client/setup.py
+++ b/watchdog_client/setup.py
@@ -7,7 +7,7 @@ from setuptools import (
 
 setup(
     name='skale-watchdog-client',
-    version='1.1',
+    version='1.2',
     description='SKALE Watchdog Client - SKALE and FAIR Nodes Health Checks',
     author='SKALE Labs',
     author_email='support@skalelabs.com',

--- a/watchdog_client/watchdog_client/__init__.py
+++ b/watchdog_client/watchdog_client/__init__.py
@@ -120,12 +120,6 @@ class SkaleNode(NodeBase):
     def validator_nodes(self, **params: Any) -> ApiResult:
         return self._get(self._path(self.bp, 'validator-nodes'), params)
 
-    def sm_abi_hash(self, **params: Any) -> ApiResult:
-        return self._get(self._path(self.bp, 'sm-abi'), params)
-
-    def ima_abi_hash(self, **params: Any) -> ApiResult:
-        return self._get(self._path(self.bp, 'ima-abi'), params)
-
 
 class FairNode(NodeBase):
     bp = 'fair'

--- a/watchdog_client/watchdog_client/__init__.py
+++ b/watchdog_client/watchdog_client/__init__.py
@@ -69,6 +69,8 @@ class NodeBase:
         excluded_names = {'all_checks', 'session', 'base_url', 'timeout'}
         if self.__class__.__name__ == 'FairPassiveNode':
             excluded_names.add('sgx')
+        if self.__class__.__name__ == 'SkalePassiveNode':
+            excluded_names.update({'sgx', 'schains', 'ima', 'validator_nodes'})
         results: Dict[str, ApiResult] = {}
         for name in sorted(dir(self)):
             if name.startswith('_') or name in excluded_names:
@@ -121,6 +123,36 @@ class SkaleNode(NodeBase):
         return self._get(self._path(self.bp, 'validator-nodes'), params)
 
 
+class SkalePassiveNode(SkaleNode):
+    def sgx(self, **params: Any) -> ApiResult:
+        return ApiResult(
+            data=None,
+            error='SGX check is not available on SKALE passive nodes',
+            status_code=404,
+        )
+
+    def schains(self, **params: Any) -> ApiResult:
+        return ApiResult(
+            data=None,
+            error='schains check is not available on SKALE passive nodes',
+            status_code=404,
+        )
+
+    def ima(self, **params: Any) -> ApiResult:
+        return ApiResult(
+            data=None,
+            error='IMA check is not available on SKALE passive nodes',
+            status_code=404,
+        )
+
+    def validator_nodes(self, **params: Any) -> ApiResult:
+        return ApiResult(
+            data=None,
+            error='Validator nodes check is not available on SKALE passive nodes',
+            status_code=404,
+        )
+
+
 class FairNode(NodeBase):
     bp = 'fair'
 
@@ -140,4 +172,4 @@ class FairPassiveNode(FairNode):
         )
 
 
-__all__ = ['ApiResult', 'NodeBase', 'SkaleNode', 'FairNode', 'FairPassiveNode']
+__all__ = ['ApiResult', 'NodeBase', 'SkaleNode', 'SkalePassiveNode', 'FairNode', 'FairPassiveNode']


### PR DESCRIPTION
This pull request introduces support for SKALE passive nodes by adding a new `SkalePassiveNode` class and updating the health check logic to handle endpoints that are unavailable in passive mode. The documentation and packaging configuration are also updated to reflect these changes and improve clarity.

**Support for SKALE Passive Nodes:**

* Added the `SkalePassiveNode` class, which overrides the `sgx`, `schains`, `ima`, and `validator_nodes` methods to return a 404 error, indicating these checks are not available on SKALE passive nodes. The `all_checks` method is updated to exclude these endpoints for passive nodes. (`watchdog_client/__init__.py`, [[1]](diffhunk://#diff-d01f411a2f32baa2bf1b181dccc66d4571af1c85cf38f05967396e348e026dc3R43-R47) [[2]](diffhunk://#diff-9513e4286dff18bf736a0207b5dc6541597a77292455cf23f6959dba5df88caeR72-R73) [[3]](diffhunk://#diff-9513e4286dff18bf736a0207b5dc6541597a77292455cf23f6959dba5df88caeL123-R153) [[4]](diffhunk://#diff-9513e4286dff18bf736a0207b5dc6541597a77292455cf23f6959dba5df88caeL149-R175)

**Documentation updates:**

* Updated the `README.md` to include usage examples for `SkalePassiveNode`, clarify which endpoints are unavailable in passive mode, and improve example hostnames for clarity. (`watchdog_client/README.md`, [[1]](diffhunk://#diff-c4d5224517c76afda4c73b1516ad3d3197b03abd7329526cc8a62f216a2c7434L18-R27) [[2]](diffhunk://#diff-c4d5224517c76afda4c73b1516ad3d3197b03abd7329526cc8a62f216a2c7434L59-R70)

**Configuration and packaging:**

* Updated `pyproject.toml` to include the `configs` and `utils` packages for setuptools discovery. (`pyproject.toml`, [pyproject.tomlR41-R43](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711R41-R43))
* Bumped the package version to `1.2` in `setup.py`. (`watchdog_client/setup.py`, [watchdog_client/setup.pyL10-R10](diffhunk://#diff-83f25517f93354a8fa6d7a23d94ef97a1ed8afa46cfede9991815356bb59dfbdL10-R10))

**Cleanup and removal of unused endpoints:**

* Removed the `sm_abi_hash` and `ima_abi_hash` endpoints from both the code and documentation, as these are no longer needed. (`configs/__init__.py`, [[1]](diffhunk://#diff-d01f411a2f32baa2bf1b181dccc66d4571af1c85cf38f05967396e348e026dc3L32-L38); `watchdog_client/__init__.py`, [[2]](diffhunk://#diff-9513e4286dff18bf736a0207b5dc6541597a77292455cf23f6959dba5df88caeL123-R153); `watchdog_client/README.md`, [[3]](diffhunk://#diff-c4d5224517c76afda4c73b1516ad3d3197b03abd7329526cc8a62f216a2c7434L59-R70)