### PR TITLE
Fix version calculation for `watchdog-client`

### DIFF
--- a/watchdog_client/scripts/calculate_version.sh
+++ b/watchdog_client/scripts/calculate_version.sh
@@ -23,7 +23,7 @@ if [[ $BRANCH == 'stable' ]]; then
     echo "$VERSION"
     exit 0
 elif [[ $BRANCH == 'develop' ]]; then
-    OUTPUT_TYPE="dev"
+    OUTPUT_TYPE=".dev"
 elif [[ $BRANCH == 'beta' ]]; then
     OUTPUT_TYPE="b"
 else
@@ -36,17 +36,13 @@ git fetch --tags > /dev/null
 NUMBER=0
 
 while true; do
-    TAG_CANDIDATE="${VERSION}${BRANCH}${NUMBER}"
-    if ! git tag -l "${TAG_CANDIDATE}" | grep -q "${TAG_CANDIDATE}" ; then
-        # Construct PEP 440 compliant output
-        if [[ $BRANCH == 'develop' ]]; then
-            echo "${VERSION}.dev${NUMBER}" | tr / -
-        elif [[ $BRANCH == 'beta' ]]; then
-            echo "${VERSION}b${NUMBER}" | tr / -
-        else
-            echo "${VERSION}" | tr / -
-        fi
+    CANDIDATE="${VERSION}${OUTPUT_TYPE}${NUMBER}"
+    GITHUB_TAG="${VERSION}-${BRANCH}.${NUMBER}"
+
+    if git tag -l "${GITHUB_TAG}" | grep -q "^${GITHUB_TAG}$"; then
+        NUMBER=$((NUMBER+1))
+    else
+        echo "${CANDIDATE}" | tr / -
         break
     fi
-    NUMBER=$((NUMBER+1))
 done


### PR DESCRIPTION
This pull request updates the version calculation script to improve consistency and compliance with versioning standards, especially for the `develop` branch. The main changes include making the output for the `develop` branch PEP 440 compliant and refining how version tags are constructed and checked for uniqueness.

**Versioning and Output Format Improvements:**

* Changed the `OUTPUT_TYPE` for the `develop` branch from `"dev"` to `".dev"` to ensure PEP 440 compliance.
* Refactored the version candidate and tag-checking logic to use a consistent `CANDIDATE` and `GITHUB_TAG` format, and updated the loop to increment the version number only if the tag already exists, ensuring unique and properly formatted version outputs.